### PR TITLE
Improve WASM bindings

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -31,6 +31,10 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --all --all-features --all-targets -- -D warnings
+
   build-and-test:
     name: Test rust and wasm bindings
     runs-on: ubuntu-latest
@@ -44,5 +48,16 @@ jobs:
         with:
           toolchain: stable
 
-      - run: GIT_TRACE=1 cargo test --all -- --nocapture
-#      - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh;curl -fsSL https://deno.land/install.sh | sh;wasm-pack build -t web wrapper/wasm-ll;deno test -A wrapper/wasm-ll/tests/tests.ts
+      - name: install wasm-pack
+        run: cargo install wasm-pack
+
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.44
+
+      - run: cargo test --all
+
+      - run: wasm-pack build -t web wrapper/wasm-ll
+
+      - name: wasm test
+        run: deno test -A wrapper/wasm-ll/tests/tests.ts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -72,24 +72,24 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -104,12 +104,6 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -120,7 +114,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -182,7 +176,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -222,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
@@ -261,7 +255,7 @@ version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
@@ -286,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -324,18 +318,18 @@ dependencies = [
  "js-sys",
  "k256",
  "rand",
+ "rand_chacha",
  "serde",
  "serde-wasm-bindgen",
  "sl-mpc-mate",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wee_alloc",
 ]
 
 [[package]]
 name = "dkls23-ll"
-version = "1.0.1"
+version = "1.0.3"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -394,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elliptic-curve"
@@ -430,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "futures-core"
@@ -491,11 +485,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -515,11 +509,11 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crunchy",
 ]
 
@@ -549,15 +543,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -568,7 +562,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -588,21 +582,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "merlin"
@@ -624,15 +612,15 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -652,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "poly1305"
@@ -675,18 +663,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -723,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -771,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scoped-tls"
@@ -798,15 +786,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -833,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -844,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -869,7 +857,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -887,7 +875,7 @@ dependencies = [
 [[package]]
 name = "sl-mpc-mate"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git#0a68953767e44e92af6629bfb6178ee2b900e1f3"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=0a68953767e44e92af6629bfb6178ee2b900e1f3#0a68953767e44e92af6629bfb6178ee2b900e1f3"
 dependencies = [
  "aead",
  "base64",
@@ -917,7 +905,7 @@ dependencies = [
 [[package]]
 name = "sl-oblivious"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git#0a68953767e44e92af6629bfb6178ee2b900e1f3"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=0a68953767e44e92af6629bfb6178ee2b900e1f3#0a68953767e44e92af6629bfb6178ee2b900e1f3"
 dependencies = [
  "bytemuck",
  "elliptic-curve",
@@ -959,9 +947,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -970,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1030,19 +1018,19 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -1055,11 +1043,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1067,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1077,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1090,15 +1078,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143ddeb4f833e2ed0d252e618986e18bfc7b0e52f2d28d77d05b2f045dd8eb61"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1110,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.41"
+version = "0.3.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5211b7550606857312bba1d978a8ec75692eae187becc5e680444fffc5e6f89"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,47 +1109,13 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x25519-dalek"
@@ -1177,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ sha2 = "0.10.8"
 k256 = "0.13.2"
 merlin = "3.0.0"
 rand = "0.8"
-thiserror = "=1.0.49"     # 1.0.50 is broken
+rand_chacha = "0.3"
+thiserror = "1.0"
 derivation-path = "0.2.0"
 zeroize = "1.6.1"
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
-//!
-
 use crate::VERSION;
 use sl_oblivious::label::Label;
 

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -6,6 +6,7 @@
 //! while Structs only with  from_id: u8 are distributed to each party
 //! Proper validation of each input at each round is needed when deployed in a real world.
 #![allow(missing_docs)]
+
 use std::collections::HashSet;
 
 use k256::{
@@ -38,14 +39,14 @@ use crate::{constants::*, pairs::*, utils::*};
 
 pub use crate::error::KeygenError;
 
-///
+/// Description of a party
 pub struct Party {
     pub ranks: Vec<u8>, // ranks of parties
     pub t: u8,
     pub party_id: u8,
 }
 
-///
+/// First DKG message
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct KeygenMsg1 {
     pub from_id: u8,
@@ -72,7 +73,7 @@ pub struct KeygenMsg2 {
     dlog_proofs: Vec<DLogProof>,
 }
 
-///
+/// Third DKG message
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct KeygenMsg3 {
     pub from_id: u8,
@@ -85,7 +86,6 @@ pub struct KeygenMsg3 {
     #[zeroize(skip)]
     big_f_vec: GroupPolynomial<Secp256k1>,
 
-    ///
     d_i: Scalar,
 
     /// base OT msg 2
@@ -104,7 +104,7 @@ pub struct KeygenMsg3 {
     r_i_2: [u8; 32],
 }
 
-///
+/// Forth DKG message
 #[derive(Clone, Serialize, Deserialize)]
 pub struct KeygenMsg4 {
     pub from_id: u8,
@@ -198,7 +198,6 @@ impl Party {
 }
 
 impl State {
-    ///
     pub fn new<R: RngCore + CryptoRng>(
         party: Party,
         rng: &mut R,
@@ -267,7 +266,6 @@ impl State {
         }
     }
 
-    ///
     pub fn key_rotation<R: RngCore + CryptoRng>(
         oldshare: &Keyshare,
         rng: &mut R,
@@ -277,6 +275,7 @@ impl State {
             party_id: oldshare.party_id,
             t: oldshare.threshold,
         };
+
         Self::new(
             party,
             rng,
@@ -295,7 +294,6 @@ impl State {
         Self::new(Party::new(n, t, party_id), rng, Some(x_i))
     }
 
-    ///
     pub fn generate_msg1(&self) -> KeygenMsg1 {
         KeygenMsg1 {
             from_id: self.party_id,
@@ -797,7 +795,6 @@ impl State {
     }
 }
 
-///
 pub struct RefreshShare {
     /// Rank of each party. Initialize by vector of zeroes if your
     /// external key share does not have them.
@@ -814,7 +811,6 @@ pub struct RefreshShare {
     pub s_i: Scalar,
     /// List of s_i * G for each party. That is big_s_list[party_id] == s_i *G.
     pub big_s_list: Vec<AffinePoint>,
-    ///
     pub x_i_list: Vec<NonZeroScalar>,
 }
 

--- a/src/dsg.rs
+++ b/src/dsg.rs
@@ -205,6 +205,19 @@ impl State {
         }
 
         for msg in msgs {
+            // make sure msg is unique
+            if self
+                .sid_list
+                .iter()
+                .any(|(p, v)| (p != &msg.from_id) && (v == &msg.session_id))
+                || self
+                    .commitment_r_i_list
+                    .iter()
+                    .any(|(_, v)| v == &msg.commitment_r_i)
+            {
+                return Err(SignError::MissingMessage);
+            }
+
             self.sid_list.push(msg.from_id, msg.session_id);
             self.commitment_r_i_list
                 .push(msg.from_id, msg.commitment_r_i);

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,17 +48,12 @@ pub enum KeygenError {
     /// PPRF error
     PPRFError(&'static str),
 
-    ///
     #[error("Missing message")]
     MissingMessage,
 
     #[error("Invalid key refresh")]
     /// Invalid key refresh
     InvalidKeyRefresh,
-
-    /// Some party decided to not participate in the protocol.
-    #[error("Abort protocol by party {0}")]
-    AbortProtocol(u8),
 }
 
 /// Distributed key generation errors
@@ -84,13 +79,8 @@ pub enum SignError {
     #[error("k256 error: {0}")]
     K256Error(#[from] k256::ecdsa::Error),
 
-    ///
     #[error("Missing message")]
     MissingMessage,
-
-    /// Some party decided to not participate in the protocol.
-    #[error("Abort protocol by party {0}")]
-    AbortProtocol(u8),
 
     /// Abort the protocol and ban the party
     #[error("Abort the protocol and ban the party {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum KeygenError {
     #[error("Big S value mismatch")]
     BigSMismatch,
 
-    #[error("PPRF error")]
+    #[error("PPRF error {0}")]
     /// PPRF error
     PPRFError(&'static str),
 

--- a/src/pairs.rs
+++ b/src/pairs.rs
@@ -103,7 +103,6 @@ impl<T, I: Ord> Pairs<T, I> {
 }
 
 impl<T, I: Ord> Pairs<T, I> {
-    ///
     pub fn no_dups_by<F>(&self, eq: F) -> bool
     where
         F: Fn(&T, &T) -> bool,
@@ -128,7 +127,6 @@ impl<T, I: Ord> Pairs<T, I> {
 }
 
 impl<T: Eq, I: Ord> Pairs<T, I> {
-    ///
     pub fn no_dups(&self) -> bool {
         self.no_dups_by(|a, b| a.eq(b))
     }

--- a/wrapper/wasm-ll/Cargo.toml
+++ b/wrapper/wasm-ll/Cargo.toml
@@ -11,12 +11,12 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-wee_alloc = "0.4.5"
 derivation-path.workspace = true
 getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen = "0.2.88"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6.0"
+rand_chacha.workspace = true
 js-sys = "0.3"
 dkls23-ll = { path = "../.." }
 sl-mpc-mate = { workspace = true }
@@ -32,4 +32,4 @@ serde = "1"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.34"
+wasm-bindgen-test = "0.3.42"

--- a/wrapper/wasm-ll/README.md
+++ b/wrapper/wasm-ll/README.md
@@ -213,3 +213,17 @@ not automatic memory managment and caller is responsible to call
 Methods `.handleMessages()` consumes passed in messages. This means
 that caller have to call `.free()` methods only to deallocate objects
 as part of error handling.
+
+## Error handling
+
+session.handleMessages() may throw an error. It is impossitle to
+recover from the error.  It is impossible to continue execition of a
+protocol.
+
+In most cases err.message only could help to debug an application.
+
+One special case MUST be handled.
+
+SignSession.handleMessages() could throw an error AbortProtocolAndBanParty.
+In this case, the error object has property "banParty", the value is
+in range [0 .. threshold-1]. Zero is valid party ID!

--- a/wrapper/wasm-ll/src/errors.rs
+++ b/wrapper/wasm-ll/src/errors.rs
@@ -1,0 +1,30 @@
+use js_sys::{Error, Reflect};
+use wasm_bindgen::{prelude::*, throw_str};
+
+use dkls23_ll::{dkg::KeygenError, dsg::SignError};
+
+fn set_party_id(js_err: &js_sys::Error, prop: &str, party_id: u8) {
+    let ok = Reflect::set(
+        js_err,
+        &JsValue::from_str(prop),
+        &JsValue::from_f64(party_id as _),
+    );
+
+    if ok != Ok(true) {
+        throw_str("expect to set property on an error object");
+    }
+}
+
+pub fn keygen_error(err: KeygenError) -> js_sys::Error {
+    Error::new(&err.to_string())
+}
+
+pub fn sign_error(err: SignError) -> js_sys::Error {
+    let js_err = Error::new(&err.to_string());
+
+    if let SignError::AbortProtocolAndBanParty(p) = err {
+        set_party_id(&js_err, "banParty", p);
+    }
+
+    js_err
+}

--- a/wrapper/wasm-ll/src/lib.rs
+++ b/wrapper/wasm-ll/src/lib.rs
@@ -1,14 +1,24 @@
 // Copyright (c) Silence Laboratories Pte. Ltd. All Rights Reserved.
 // This software is licensed under the Silence Laboratories License Agreement.
 
-extern crate wee_alloc;
+use rand::prelude::*;
+use rand_chacha::ChaCha20Rng;
 
-// Use `wee_alloc` as the global allocator.
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+use wasm_bindgen::prelude::*;
 
 mod keygen;
 mod keyshare;
 mod message;
 mod sign;
 mod utils;
+
+pub fn maybe_seeded_rng<T: AsRef<[u8]>>(seed: Option<T>) -> ChaCha20Rng {
+    let seed = match seed.as_ref() {
+        None => rand::thread_rng().gen(),
+        Some(seed) => {
+            seed.as_ref().try_into().expect_throw("invalid seed size")
+        }
+    };
+
+    ChaCha20Rng::from_seed(seed)
+}

--- a/wrapper/wasm-ll/src/lib.rs
+++ b/wrapper/wasm-ll/src/lib.rs
@@ -6,6 +6,7 @@ use rand_chacha::ChaCha20Rng;
 
 use wasm_bindgen::prelude::*;
 
+mod errors;
 mod keygen;
 mod keyshare;
 mod message;

--- a/wrapper/wasm-ll/src/sign.rs
+++ b/wrapper/wasm-ll/src/sign.rs
@@ -4,13 +4,14 @@
 use std::str::FromStr;
 
 use derivation_path::DerivationPath;
-use js_sys::{Array, Uint8Array};
+use js_sys::{Array, Error, Uint8Array};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use wasm_bindgen::{prelude::*, throw_str};
+use wasm_bindgen::prelude::*;
 
 use dkls23_ll::dsg;
 
 use crate::{
+    errors::sign_error,
     keyshare::Keyshare,
     maybe_seeded_rng,
     message::{Message, MessageRouting},
@@ -24,12 +25,10 @@ enum Round {
     WaitMsg3,
     Pre(dsg::PreSignature),
     WaitMsg4(dsg::PartialSignature),
-    Error(String),
-    Sign(Vec<u8>),
-    Invalid,
+    Failed,
+    Finished,
 }
 
-///
 #[derive(Serialize, Deserialize)]
 #[wasm_bindgen]
 pub struct SignSession {
@@ -79,26 +78,24 @@ impl SignSession {
 
     /// Return an error message, if any.
     #[wasm_bindgen(js_name = error)]
-    pub fn error(&self) -> Option<String> {
+    pub fn error(&self) -> Option<Error> {
         match &self.round {
-            Round::Error(err) => Some(err.clone()),
+            Round::Failed => Some(Error::new("failed")),
             _ => None,
         }
     }
 
     /// Create a fist message and change session state from Init to WaitMg1.
     #[wasm_bindgen(js_name = createFirstMessage)]
-    pub fn create_first_message(&mut self) -> Message {
-        if !matches!(self.round, Round::Init) {
-            throw_str("invalid state");
+    pub fn create_first_message(&mut self) -> Result<Message, Error> {
+        match self.round {
+            Round::Init => {
+                self.round = Round::WaitMsg1;
+                Ok(Message::new(self.state.generate_msg1()))
+            }
+
+            _ => Err(Error::new("invalid state")),
         }
-
-        let msg1 = self.state.generate_msg1();
-        let msg1 = Message::new(msg1);
-
-        self.round = Round::WaitMsg1;
-
-        msg1
     }
 
     fn handle<T, U, H>(
@@ -106,7 +103,7 @@ impl SignSession {
         msgs: Vec<Message>,
         mut h: H,
         next: Round,
-    ) -> Result<Vec<Message>, JsError>
+    ) -> Result<Vec<Message>, Error>
     where
         T: DeserializeOwned,
         U: Serialize + MessageRouting,
@@ -121,8 +118,8 @@ impl SignSession {
             }
 
             Err(err) => {
-                self.round = Round::Error(err.to_string());
-                Err(JsError::new("process message"))
+                self.round = Round::Failed;
+                Err(sign_error(err))
             }
         }
     }
@@ -134,7 +131,7 @@ impl SignSession {
         &mut self,
         msgs: Vec<Message>,
         seed: Option<Vec<u8>>,
-    ) -> Result<Vec<Message>, JsError> {
+    ) -> Result<Vec<Message>, Error> {
         let mut rng = maybe_seeded_rng(seed);
 
         match &self.round {
@@ -162,9 +159,9 @@ impl SignSession {
                 Ok(vec![])
             }
 
-            Round::Error(err) => Err(JsError::new(err.as_ref())),
+            Round::Failed => Err(Error::new("failed")),
 
-            _ => Err(JsError::new("invalid session state")),
+            _ => Err(Error::new("invalid session state")),
         }
     }
 
@@ -174,12 +171,12 @@ impl SignSession {
     pub fn last_message(
         &mut self,
         message_hash: &[u8],
-    ) -> Result<Message, JsError> {
+    ) -> Result<Message, Error> {
         if message_hash.len() != 32 {
-            return Err(JsError::new("invalid message hash"));
+            return Err(Error::new("invalid message hash"));
         }
 
-        match core::mem::replace(&mut self.round, Round::Invalid) {
+        match core::mem::replace(&mut self.round, Round::Finished) {
             Round::Pre(pre) => {
                 let hash = message_hash.try_into().unwrap();
                 let (partial, msg4) =
@@ -192,7 +189,7 @@ impl SignSession {
 
             prev => {
                 self.round = prev;
-                Err(JsError::new("invalid state"))
+                Err(Error::new("invalid state"))
             }
         }
     }

--- a/wrapper/wasm-ll/tests/tests.ts
+++ b/wrapper/wasm-ll/tests/tests.ts
@@ -4,6 +4,8 @@
 // to run tests we need web build
 // wasm-pack build -t web ..
 
+import { assertEquals, assertThrows } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
 import initDkls from '../pkg/dkls_wasm_ll.js';
 import {KeygenSession, Keyshare} from '../pkg/dkls_wasm_ll.js';
 import {SignSession, Message} from '../pkg/dkls_wasm_ll.js';
@@ -89,7 +91,6 @@ function dsg(shares: Keyshare[], t: number, messageHash: Uint8Array) {
     return signs;
 }
 
-
 test('DKG 3x2', async () => {
     let shares = dkg(3,2);
 });
@@ -121,4 +122,30 @@ test('Key rotation', async() => {
     new_shares.forEach((s, i) => s.finishKeyRotation(shares[i]));
 
     let new_signs = dsg(new_shares, 2, messageHash);
+});
+
+test('DKG session should fail', () => {
+
+    let s = new KeygenSession(3, 2, 1);
+    let m = s.createFirstMessage();
+
+    assertThrows(() => s.createFirstMessage())
+
+    assertThrows(() => s.handleMessages([m]));
+});
+
+test('DSG session should fail', () => {
+    // run DKG to get a key shares
+    let shares = dkg(3,2);
+
+    let s = new SignSession(shares[0], "m");
+    let m = s.createFirstMessage();
+
+    // trying to create first message more then
+    // one should fail.
+    assertThrows(() => s.createFirstMessage())
+
+    // passing a message create by a session to
+    // the same session should fail.
+    assertThrows(() => s.handleMessages([m]));
 });


### PR DESCRIPTION
- removed wee_alloc
- removed unused `KeygenError::AbortProtocol` and `SignError::AbortProtocol`
- allow to seed RNG. All methods that require RNG now takes optional parameter seed. maybe_seeded_rng(seed)
return fresh instance of ChaCha20Rng, seeded either from passed seed or from seed generated from     rand::thread_rng().
- KeygenSession::error() and SignSession:error() now returns text representation of session's error if any.
- KeygenSession::handleMessages() and SignSession::handleMessage() throws a Error instead of string
- run `cargo clippy` by CI job
- added CI job to run wasm bindings tests
- added message validation for `dsg::State::handle_msg1()`

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [x] 🔁 CI/CD
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets
Fixes # (issue)


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

