### PR TITLE
Recovery of lost key_shares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,34 +204,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "fiat-crypto",
- "platforms",
- "rustc_version",
- "serde",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +322,6 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "futures-core"
@@ -553,12 +519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,15 +612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,12 +637,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -778,7 +723,7 @@ dependencies = [
 [[package]]
 name = "sl-mpc-mate"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=c32971a7a2ba43b92c02a45d0cf9fec8f3af521b#c32971a7a2ba43b92c02a45d0cf9fec8f3af521b"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=2c199ed#2c199edb0756c5d5240d30907a397d20cce15fba"
 dependencies = [
  "base64",
  "bs58",
@@ -802,7 +747,7 @@ dependencies = [
 [[package]]
 name = "sl-oblivious"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=c32971a7a2ba43b92c02a45d0cf9fec8f3af521b#c32971a7a2ba43b92c02a45d0cf9fec8f3af521b"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=2c199ed#2c199edb0756c5d5240d30907a397d20cce15fba"
 dependencies = [
  "bytemuck",
  "elliptic-curve",
@@ -813,7 +758,6 @@ dependencies = [
  "serde",
  "serde_arrays",
  "thiserror",
- "x25519-dalek",
  "zeroize",
 ]
 
@@ -1002,18 +946,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek",
- "rand_core",
- "serde",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,9 +16,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -109,30 +99,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,17 +123,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -245,7 +200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
 ]
 
@@ -258,7 +212,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
  "platforms",
  "rustc_version",
@@ -360,30 +313,6 @@ dependencies = [
  "serdect",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -533,15 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,12 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,17 +557,6 @@ name = "platforms"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -875,37 +778,31 @@ dependencies = [
 [[package]]
 name = "sl-mpc-mate"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=0a68953767e44e92af6629bfb6178ee2b900e1f3#0a68953767e44e92af6629bfb6178ee2b900e1f3"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=c32971a7a2ba43b92c02a45d0cf9fec8f3af521b#c32971a7a2ba43b92c02a45d0cf9fec8f3af521b"
 dependencies = [
- "aead",
  "base64",
  "bs58",
- "chacha20",
- "chacha20poly1305",
+ "bytemuck",
  "derivation-path",
- "ed25519-dalek",
  "elliptic-curve",
  "futures-util",
- "generic-array",
  "hex",
  "hmac",
  "k256",
  "rand",
  "rand_core",
- "rayon",
  "ripemd",
  "serde",
  "sha2",
  "subtle",
  "thiserror",
- "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "sl-oblivious"
 version = "0.1.0"
-source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=0a68953767e44e92af6629bfb6178ee2b900e1f3#0a68953767e44e92af6629bfb6178ee2b900e1f3"
+source = "git+https://github.com/silence-laboratories/sl-crypto.git?rev=c32971a7a2ba43b92c02a45d0cf9fec8f3af521b#c32971a7a2ba43b92c02a45d0cf9fec8f3af521b"
 dependencies = [
  "bytemuck",
  "elliptic-curve",
@@ -987,16 +884,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ thiserror = "1.0"
 derivation-path = "0.2.0"
 zeroize = "1.6.1"
 
-sl-mpc-mate = { git = "https://github.com/silence-laboratories/sl-crypto.git", rev = "c32971a7a2ba43b92c02a45d0cf9fec8f3af521b" }
-sl-oblivious = { git = "https://github.com/silence-laboratories/sl-crypto.git", rev = "c32971a7a2ba43b92c02a45d0cf9fec8f3af521b" }
+sl-mpc-mate = { git = "https://github.com/silence-laboratories/sl-crypto.git", rev = "2c199ed" }
+sl-oblivious = { git = "https://github.com/silence-laboratories/sl-crypto.git", rev = "2c199ed" }
 
 [profile.release]
 lto = true

--- a/Dockerfile.wasm
+++ b/Dockerfile.wasm
@@ -12,7 +12,7 @@
 #     "cd pkg-node; npm publish"
 #
 
-FROM rust:1.76 as builder
+FROM rust:1.78 as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -46,6 +46,87 @@ pub struct Party {
     pub party_id: u8,
 }
 
+#[derive(Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct KeyRefreshData {
+    /// Additive share of participant_i (after interpolation)
+    /// \sum_{i=0}^{n-1} s_i_0 = private_key
+    /// s_i_0 can be equal to Zero in case when participant lost their key_share
+    /// and wants to recover it during key_refresh
+    s_i_0: Scalar,
+
+    /// list of participants ids who lost their key_shares
+    /// should be in range [0, n-1]
+    lost_keyshare_party_ids: Vec<u8>,
+
+    /// expected public key for key_refresh
+    expected_public_key: AffinePoint,
+
+    /// root_chain_code
+    root_chain_code: [u8; 32],
+}
+
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct RefreshShare {
+    /// Rank of each party. Initialize by vector of zeroes if your
+    /// external key share does not have them.
+    pub rank_list: Vec<u8>,
+    /// Threshold value
+    pub threshold: u8,
+    /// Party Id of the sender
+    pub party_id: u8,
+    /// Public key.
+    pub public_key: AffinePoint,
+    /// Root chain code (used to derive child public keys)
+    pub root_chain_code: [u8; 32],
+    /// Private key additive share
+    /// set s_i to None if party_i lost their key_share
+    pub s_i: Option<Scalar>,
+    /// set x_i_list to None if party_i lost their key_share
+    pub x_i_list: Option<Vec<NonZeroScalar>>,
+    /// list of participants ids who lost their key_shares,
+    /// should be in range [0, n-1]
+    pub lost_keyshare_party_ids: Vec<u8>,
+}
+
+impl RefreshShare {
+    /// Create RefreshShare struct from Keyshare
+    pub fn from_keyshare(
+        keyshare: &Keyshare,
+        lost_keyshare_party_ids: Option<&[u8]>,
+    ) -> Self {
+        Self {
+            rank_list: keyshare.rank_list.clone(),
+            threshold: keyshare.threshold,
+            party_id: keyshare.party_id,
+            public_key: keyshare.public_key,
+            root_chain_code: keyshare.root_chain_code,
+            s_i: Some(keyshare.s_i),
+            x_i_list: Some(keyshare.x_i_list.clone()),
+            lost_keyshare_party_ids: lost_keyshare_party_ids
+                .unwrap_or_default()
+                .to_vec(),
+        }
+    }
+
+    /// Create RefreshShare struct for the participant who lost their keyshare
+    pub fn from_lost_keyshare(
+        party: Party,
+        public_key: AffinePoint,
+        lost_keyshare_party_ids: Vec<u8>,
+    ) -> Self {
+        Self {
+            rank_list: party.ranks,
+            threshold: party.t,
+            party_id: party.party_id,
+            public_key,
+            root_chain_code: [0u8; 32],
+            s_i: None,
+            x_i_list: None,
+            lost_keyshare_party_ids,
+        }
+    }
+}
+
 /// First DKG message
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct KeygenMsg1 {
@@ -147,7 +228,7 @@ pub struct State {
     party_id: u8,
     ranks: Vec<u8>,
     t: u8,
-    key_refresh: bool,
+    key_refresh_data: Option<KeyRefreshData>,
 
     pub final_session_id: [u8; 32],
     #[zeroize(skip)] // FIXME we must zeroize this field
@@ -198,13 +279,29 @@ impl Party {
 }
 
 impl State {
-    pub fn new<R: RngCore + CryptoRng>(
+    /// Initialize generation of a new distributed key
+    pub fn new<R: RngCore + CryptoRng>(party: Party, rng: &mut R) -> Self {
+        Self::new_with_refresh(party, rng, None).unwrap()
+    }
+
+    fn new_with_refresh<R: RngCore + CryptoRng>(
         party: Party,
         rng: &mut R,
-        x_i: Option<&NonZeroScalar>,
-    ) -> Self {
+        key_refresh_data: Option<KeyRefreshData>,
+    ) -> Result<Self, KeygenError> {
         let Party { party_id, ranks, t } = party;
-        let key_refresh = x_i.is_some();
+
+        let my_party_id = party_id;
+        let n = ranks.len() as u8;
+        if let Some(v) = &key_refresh_data {
+            let cond1 = v.expected_public_key.is_identity().into();
+            let cond2 = v.lost_keyshare_party_ids.len() > (n - t) as usize;
+            let cond3 = v.s_i_0.is_zero().into()
+                && !v.lost_keyshare_party_ids.contains(&my_party_id);
+            if cond1 || cond2 || cond3 {
+                return Err(KeygenError::InvalidKeyRefresh);
+            }
+        }
 
         // currently we support only zero ranks in this impl.
         assert!(ranks.iter().all(|&r| r == 0));
@@ -214,14 +311,11 @@ impl State {
 
         // u_i_k
         let mut polynomial = Polynomial::random(rng, t as usize - 1);
-        if key_refresh {
-            polynomial.reset_contant();
+        if let Some(v) = &key_refresh_data {
+            polynomial.set_constant(v.s_i_0);
         }
 
-        let x_i = match x_i {
-            Some(x_i) => *x_i,
-            None => NonZeroScalar::random(rng),
-        };
+        let x_i = NonZeroScalar::random(&mut *rng);
 
         let big_f_i_vec = polynomial.commit();
 
@@ -238,11 +332,18 @@ impl State {
         let d_i =
             polynomial.derivative_at(ranks[party_id as usize] as usize, &x_i);
 
-        Self {
+        // generate chain_code_sid for root_chain_code or use already existed from key_refresh_data
+        let chain_code_sid = if let Some(v) = &key_refresh_data {
+            v.root_chain_code
+        } else {
+            rng.gen()
+        };
+
+        Ok(Self {
             party_id,
             ranks,
             t,
-            key_refresh,
+            key_refresh_data,
             polynomial,
 
             r_i_2: rng.gen(),
@@ -251,7 +352,7 @@ impl State {
             r_i_list: Pairs::new_with_item(party_id, r_i),
             d_i_list: Pairs::new_with_item(party_id, d_i),
             commitment_list: Pairs::new_with_item(party_id, commitment),
-            chain_code_sids: Pairs::new_with_item(party_id, rng.gen()),
+            chain_code_sids: Pairs::new_with_item(party_id, chain_code_sid),
             root_chain_code: [0; 32],
             big_f_vec: GroupPolynomial::identity(t as usize),
             big_f_i_vecs: Pairs::new_with_item(party_id, big_f_i_vec.clone()),
@@ -263,35 +364,63 @@ impl State {
             seed_ot_receivers: Pairs::new(),
             seed_i_j_list: Pairs::new(),
             seed_ot_senders: Pairs::new(),
-        }
+        })
     }
 
+    pub fn key_refresh<R: RngCore + CryptoRng>(
+        refresh_share: &RefreshShare,
+        rng: &mut R,
+    ) -> Result<Self, KeygenError> {
+        let party = Party {
+            ranks: refresh_share.rank_list.clone(),
+            party_id: refresh_share.party_id,
+            t: refresh_share.threshold,
+        };
+        let n = party.ranks.len();
+        let my_party_id = party.party_id;
+
+        // currently we support only zero ranks in this impl.
+        assert!(party.ranks.iter().all(|&r| r == 0));
+
+        let mut s_i_0 = Scalar::ZERO;
+        if refresh_share.s_i.is_some() && refresh_share.x_i_list.is_some() {
+            // calculate additive share s_i_0 of participant_i,
+            // \sum_{i=0}^{n-1} s_i_0 = private_key
+            let s_i = &refresh_share.s_i.unwrap();
+            let x_i_list = &refresh_share.x_i_list.clone().unwrap();
+            let x_i = &x_i_list[my_party_id as usize];
+
+            let party_ids_with_keyshares = (0..n as u8)
+                .filter(|p| {
+                    !refresh_share.lost_keyshare_party_ids.contains(p)
+                })
+                .collect::<Vec<_>>();
+
+            let lambda =
+                get_lagrange_coeff(x_i, x_i_list, &party_ids_with_keyshares);
+
+            s_i_0 = lambda * s_i;
+        }
+
+        let key_refresh_data = KeyRefreshData {
+            s_i_0,
+            lost_keyshare_party_ids: refresh_share
+                .lost_keyshare_party_ids
+                .clone(),
+            expected_public_key: refresh_share.public_key,
+            root_chain_code: refresh_share.root_chain_code,
+        };
+
+        Self::new_with_refresh(party, rng, Some(key_refresh_data))
+    }
+
+    /// Initialize refresh of an existing distributed key.
     pub fn key_rotation<R: RngCore + CryptoRng>(
         oldshare: &Keyshare,
         rng: &mut R,
-    ) -> Self {
-        let party = Party {
-            ranks: oldshare.rank_list.clone(),
-            party_id: oldshare.party_id,
-            t: oldshare.threshold,
-        };
-
-        Self::new(
-            party,
-            rng,
-            Some(&oldshare.x_i_list[oldshare.party_id as usize]),
-        )
-    }
-
-    /// Initialize DKG state for import an exteral key share.
-    pub fn from_external_share<R: RngCore + CryptoRng>(
-        n: usize,
-        t: usize,
-        party_id: usize,
-        x_i: &NonZeroScalar,
-        rng: &mut R,
-    ) -> Self {
-        Self::new(Party::new(n, t, party_id), rng, Some(x_i))
+    ) -> Result<Self, KeygenError> {
+        let refresh_share = RefreshShare::from_keyshare(oldshare, None);
+        Self::key_refresh(&refresh_share, &mut *rng)
     }
 
     pub fn generate_msg1(&self) -> KeygenMsg1 {
@@ -453,10 +582,12 @@ impl State {
 
             {
                 let mut points = big_f_i_vector.points();
-                if self.key_refresh {
-                    // for key refresh first point should be IDENTITY
-                    if points.next() != Some(&ProjectivePoint::IDENTITY) {
-                        return Err(KeygenError::InvalidPolynomialPoint);
+                if let Some(v) = &self.key_refresh_data {
+                    if v.lost_keyshare_party_ids.contains(&party_id) {
+                        // for participant who lost their key_share, first point should be IDENTITY
+                        if points.next() != Some(&ProjectivePoint::IDENTITY) {
+                            return Err(KeygenError::InvalidPolynomialPoint);
+                        }
                     }
                 }
                 if points.any(|p| p.is_identity().into()) {
@@ -479,10 +610,9 @@ impl State {
 
         let public_key = self.big_f_vec.get_constant();
 
-        if self.key_refresh {
-            // check that public_key == IDENTITY
-            if public_key != ProjectivePoint::IDENTITY {
-                return Err(KeygenError::InvalidPolynomialPoint);
+        if let Some(v) = &self.key_refresh_data {
+            if public_key != ProjectivePoint::from(v.expected_public_key) {
+                return Err(KeygenError::InvalidKeyRefresh);
             }
         }
 
@@ -567,6 +697,12 @@ impl State {
             return Err(KeygenError::MissingMessage);
         }
 
+        if let Some(v) = &self.key_refresh_data {
+            if v.lost_keyshare_party_ids.contains(&self.party_id) {
+                self.chain_code_sids = Pairs::new();
+            }
+        }
+
         for msg3 in msgs {
             if msg3.big_f_vec != self.big_f_vec {
                 return Err(KeygenError::BigFVecMismatch);
@@ -615,16 +751,38 @@ impl State {
                 return Err(KeygenError::InvalidCommitmentHash);
             }
 
-            self.chain_code_sids.push(msg3.from_id, msg3.chain_code_sid);
+            if let Some(v) = &self.key_refresh_data {
+                if !v.lost_keyshare_party_ids.contains(&msg3.from_id) {
+                    self.chain_code_sids
+                        .push(msg3.from_id, msg3.chain_code_sid);
+                }
+            } else {
+                self.chain_code_sids.push(msg3.from_id, msg3.chain_code_sid);
+            }
         }
 
-        // Generate common root_chain_code from chain_code_sids
-        self.root_chain_code = self
-            .chain_code_sids
-            .iter()
-            .fold(Sha256::new(), |hash, (_, sid)| hash.chain_update(sid))
-            .finalize()
-            .into();
+        if self.key_refresh_data.is_some() {
+            let chain_code_sids = self.chain_code_sids.remove_ids();
+            if chain_code_sids.is_empty() {
+                println!("error1");
+                return Err(KeygenError::InvalidKeyRefresh);
+            }
+            let root_chain_code = chain_code_sids[0];
+            if !chain_code_sids.iter().all(|&item| item == root_chain_code) {
+                println!("error2");
+                return Err(KeygenError::InvalidKeyRefresh);
+            }
+            // Use already existing root_chain_code
+            self.root_chain_code = root_chain_code;
+        } else {
+            // Generate common root_chain_code from chain_code_sids
+            self.root_chain_code = self
+                .chain_code_sids
+                .iter()
+                .fold(Sha256::new(), |hash, (_, sid)| hash.chain_update(sid))
+                .finalize()
+                .into();
+        }
 
         for ((_, big_f_i_vec), (_, f_i_val)) in
             self.big_f_i_vecs.iter().zip(self.d_i_list.iter())
@@ -795,92 +953,22 @@ impl State {
     }
 }
 
-pub struct RefreshShare {
-    /// Rank of each party. Initialize by vector of zeroes if your
-    /// external key share does not have them.
-    pub rank_list: Vec<u8>,
-    /// Threshold value
-    pub threshold: u8,
-    /// Party Id of the sender
-    pub party_id: u8,
-    /// Public key.
-    pub public_key: AffinePoint,
-    /// Root chain code (used to derive child public keys)
-    pub root_chain_code: [u8; 32],
-    /// Private key additive share
-    pub s_i: Scalar,
-    /// List of s_i * G for each party. That is big_s_list[party_id] == s_i *G.
-    pub big_s_list: Vec<AffinePoint>,
-    pub x_i_list: Vec<NonZeroScalar>,
-}
-
-impl From<Keyshare> for RefreshShare {
-    fn from(share: Keyshare) -> Self {
-        Self {
-            rank_list: share.rank_list.clone(),
-            party_id: share.party_id,
-            threshold: share.threshold,
-            root_chain_code: share.root_chain_code,
-            public_key: share.public_key,
-            s_i: share.s_i,
-            big_s_list: share.big_s_list.clone(),
-            x_i_list: share.x_i_list.clone(),
+fn get_lagrange_coeff(
+    x_i: &NonZeroScalar,
+    x_i_list: &[NonZeroScalar],
+    party_ids: &[u8],
+) -> Scalar {
+    let mut coeff = Scalar::ONE;
+    let x_i = x_i as &Scalar;
+    for &party_id in party_ids {
+        let x_j = &x_i_list[party_id as usize] as &Scalar;
+        if x_i.ct_ne(x_j).into() {
+            let sub = x_j - x_i;
+            coeff *= x_j * &sub.invert().unwrap();
         }
     }
-}
 
-impl Keyshare {
-    /// Finish key refresh protocol. This method might be used for
-    /// import of a key share generated by another protocol. Type R is
-    /// anything that could be converted to RefreshShare.
-    pub fn finish_key_rotation<R: Into<RefreshShare>>(
-        &mut self,
-        old_keyshare: R,
-    ) -> Result<(), KeygenError> {
-        let old_keyshare: RefreshShare = old_keyshare.into();
-
-        // checks for new_keyshare
-        let cond1 = (self.rank_list == old_keyshare.rank_list)
-            && (self.party_id == old_keyshare.party_id)
-            && (self.threshold == old_keyshare.threshold)
-            && (self.big_s_list.len() == old_keyshare.big_s_list.len())
-            && (self.x_i_list.len() == old_keyshare.x_i_list.len());
-
-        cond1.then_some(()).ok_or(KeygenError::InvalidKeyRefresh)?;
-
-        let mut cond2 = true;
-        for (l, r) in self.x_i_list.iter().zip(&old_keyshare.x_i_list) {
-            if l as &Scalar != r as &Scalar {
-                cond2 = false;
-            }
-        }
-        cond2.then_some(()).ok_or(KeygenError::InvalidKeyRefresh)?;
-
-        // update existed keyshare with ephemeral keyshare
-        self.public_key = old_keyshare.public_key;
-        self.root_chain_code = old_keyshare.root_chain_code;
-        self.s_i += old_keyshare.s_i;
-
-        let new_big_s_list = old_keyshare
-            .big_s_list
-            .iter()
-            .zip(&self.big_s_list)
-            .map(|(p1, p2)| p1.to_curve() + p2.to_curve())
-            .collect::<Vec<_>>();
-
-        // check secret recovery
-        check_secret_recovery(
-            &self.x_i_list,
-            &self.rank_list,
-            &new_big_s_list,
-            &self.public_key.to_curve(),
-        )?;
-
-        self.big_s_list =
-            new_big_s_list.into_iter().map(|p| p.to_affine()).collect();
-
-        Ok(())
-    }
+    coeff
 }
 
 #[cfg(test)]
@@ -932,7 +1020,6 @@ pub mod tests {
                         t,
                     },
                     &mut rng, // different seed for each party
-                    None,
                 )
             })
             .collect()
@@ -1034,15 +1121,49 @@ pub mod tests {
 
         let rotation_states = shares
             .iter()
-            .map(|s| State::key_rotation(s, &mut rng))
+            .map(|s| State::key_rotation(s, &mut rng).unwrap())
             .collect::<Vec<_>>();
 
-        let mut new_shares = dkg_inner(rotation_states);
+        let _new_shares = dkg_inner(rotation_states);
+    }
 
-        new_shares.iter_mut().zip(shares).for_each(
-            |(new_share, old_share)| {
-                new_share.finish_key_rotation(old_share).unwrap()
-            },
-        );
+    #[test]
+    fn recover_lost_share() {
+        let mut rng = rand::thread_rng();
+
+        let shares = dkg(3, 2);
+
+        let public_key = shares[0].public_key;
+
+        // party_0 key_share was lost
+        let lost_keyshare_party_ids = vec![0];
+        let party_with_lost_keyshare = Party {
+            ranks: vec![0, 0, 0],
+            t: 2,
+            party_id: 0,
+        };
+
+        let refresh_shares = vec![
+            RefreshShare::from_lost_keyshare(
+                party_with_lost_keyshare,
+                public_key,
+                lost_keyshare_party_ids.clone(),
+            ),
+            RefreshShare::from_keyshare(
+                &shares[1],
+                Some(&lost_keyshare_party_ids),
+            ),
+            RefreshShare::from_keyshare(
+                &shares[2],
+                Some(&lost_keyshare_party_ids),
+            ),
+        ];
+
+        let rotation_states = refresh_shares
+            .iter()
+            .map(|s| State::key_refresh(s, &mut rng).unwrap())
+            .collect::<Vec<_>>();
+
+        let _new_shares = dkg_inner(rotation_states);
     }
 }

--- a/wrapper/wasm-ll/src/keyshare.rs
+++ b/wrapper/wasm-ll/src/keyshare.rs
@@ -72,11 +72,10 @@ impl Keyshare {
         self.inner.party_id
     }
 
-    /// Merge new and old keyshares after key rotation.
+    /// Depricated method, the method does nothing.
+    /// It exists for backward compatibility only
     #[wasm_bindgen(js_name = finishKeyRotation)]
-    pub fn finish_key_rotation(&mut self, oldshare: Keyshare) {
-        self.inner
-            .finish_key_rotation(oldshare.into_inner())
-            .expect_throw("Key rotation error");
+    pub fn finish_key_rotation(&mut self, _oldshare: Keyshare) {
+        // empty!
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI/CD
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR adds a feature to recover lost key_shares.

In the real world, a participant can lose his key_share and no longer participate in the key refresh or sign protocol.
This PR adds changes to the key_refresh protocol that will also occur between n participants,
and which allows some participants to lose their key_shares and in the key refresh protocol, 
such participants recover their key_shares.
The recovery of the lost key_share is possible only with the consent of the other parties.

If some key_shares have been lost and all participants agree to restore those key_shares, 
then participants with valid key_shares creates RefreshShare struct from key_share 
with indicating the ID of participants who lost their key_share and startes the key_refresh protocol.
```
let refresh_share = RefreshShare::from_keyshare(keyshare, Some(lost_keyshare_party_ids));
```

Participants who have lost their key_shares creates a RefreshShare struct using the method 
`RefreshShare::from_lost_keyshare()`, providing Party struct, public_key, lost_keyshare_party_ids and also startes the key_refresh protocol.

**Note that this feature does not involve changing the t or n parameters, only restoring lost key_shares.**

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help