### PR TITLE
Add Wasm bindings for the OT variant

### DIFF
--- a/src/dsg.rs
+++ b/src/dsg.rs
@@ -30,6 +30,7 @@ pub use crate::error::SignError;
 
 /// Type for the sign gen message 1.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignMsg1 {
     pub from_id: u8,
     pub session_id: [u8; 32],

--- a/src/dsg_ot_variant.rs
+++ b/src/dsg_ot_variant.rs
@@ -21,7 +21,7 @@ use sl_mpc_mate::bip32::BIP32Error;
 
 use crate::dsg::{
     combine_partial_signature, derive_with_offset, get_lagrange_coeff,
-    get_zeta_i, PartialSignature, PreSignature, SignMsg1, SignMsg4, PS,
+    get_zeta_i, PartialSignature, PreSignature, SignMsg4, PS,
 };
 pub use crate::error::SignError;
 pub use crate::error::SignOTVariantError;
@@ -29,6 +29,18 @@ use crate::{constants::*, dkg::Keyshare, pairs::*, utils::*};
 use sl_oblivious::endemic_ot::EndemicOTReceiver;
 use sl_oblivious::rvole_ot_variant::{RVOLEMsg1, RVOLEMsg2};
 use sl_oblivious::rvole_ot_variant::{RVOLEReceiver, RVOLESender};
+
+/// Type for the sign gen message 1.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SignMsg1 {
+    pub from_id: u8,
+    pub session_id: [u8; 32],
+    pub commitment_r_i: [u8; 32],
+    // Make SignMsg1 and dsg::SignMsg1 incompatible.
+    // This allows a party to tell from the first message it receives
+    // which protocol variant its counter-party is expecting to use.
+    pub compatibility_breaking_field: u8,
+}
 
 /// Type for the sign gen message 2. P2P
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
@@ -158,6 +170,7 @@ impl State {
             from_id: party_id,
             session_id: *self.sid_list.find_pair(party_id),
             commitment_r_i: *self.commitment_r_i_list.find_pair(party_id),
+            compatibility_breaking_field: 0, // A dummy value.
         }
     }
 

--- a/wrapper/wasm-ll/src/errors.rs
+++ b/wrapper/wasm-ll/src/errors.rs
@@ -1,7 +1,9 @@
 use js_sys::{Error, Reflect};
 use wasm_bindgen::{prelude::*, throw_str};
 
-use dkls23_ll::{dkg::KeygenError, dsg::SignError};
+use dkls23_ll::{
+    dkg::KeygenError, dsg::SignError, dsg_ot_variant::SignOTVariantError,
+};
 
 fn set_party_id(js_err: &js_sys::Error, prop: &str, party_id: u8) {
     let ok = Reflect::set(
@@ -27,4 +29,8 @@ pub fn sign_error(err: SignError) -> js_sys::Error {
     }
 
     js_err
+}
+
+pub fn sign_ot_variant_error(err: SignOTVariantError) -> js_sys::Error {
+    Error::new(&err.to_string())
 }

--- a/wrapper/wasm-ll/src/lib.rs
+++ b/wrapper/wasm-ll/src/lib.rs
@@ -11,6 +11,7 @@ mod keygen;
 mod keyshare;
 mod message;
 mod sign;
+mod sign_ot_variant;
 mod utils;
 
 pub fn maybe_seeded_rng<T: AsRef<[u8]>>(seed: Option<T>) -> ChaCha20Rng {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 CI/CD
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR adds Wasm bindings for the OT variant. It intentionally separates the changes into two commits. The first commit replaces the original bindings. The second commit adds new bindings alongside the original ones. This is convenient when upgrading.

Most of the diff is simply copying, so the change is big in lines but small logically.

## Related Tickets


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

