### PR TITLE
chore: pin GitHub Actions to specific SHAs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         with:
           release-type: simple
           default-branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,20 +34,20 @@ jobs:
             build-args: VER= ${{ steps.version.outputs.tag }}
             load: true
             tags: wasm-ll:latest
-      - uses: shrink/actions-docker-extract@v3
+      - uses: shrink/actions-docker-extract@04c17c51a5b9fd93b7aed2e05e86c8fe2d90ee52 # v3.1.0
         id: extract
         with:
           image: wasm-ll:latest
           path: pkg/
           destination: dist
       - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
+        uses: thedoctor0/zip-release@b57d897cb5d60cb78b51a507f63fa184cfe35554 # 0.7.6
         with:
             type: 'zip'
             filename: 'npm-packages-${{ steps.version.outputs.tag }}-${{ matrix.platform }}-${{ matrix.arch }}.zip'
             path: dist
       - name: Upload archived  release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # 2.11.2
         with:
             asset_name: npm-packages
             repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           profile: minimal
           toolchain: stable
@@ -27,7 +27,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.1
         with:
           command: fmt
           args: --all -- --check
@@ -44,14 +44,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.6
         with:
           toolchain: stable
 
       - name: install wasm-pack
         run: cargo install wasm-pack
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
           deno-version: v1.44
 


### PR DESCRIPTION
This PR pins GitHub Actions to specific commit SHAs for security.

Related to BitGo/offline-vault-console PR #914

Ticket: IS-402

Changes:
- google-github-actions/release-please-action → v4.1.1 SHA
- shrink/actions-docker-extract → v3.1.0 SHA  
- thedoctor0/zip-release → 0.7.6 SHA
- svenstaro/upload-release-action → 2.11.2 SHA
- actions-rs/toolchain → v1.0.6 SHA (2 instances)
- actions-rs/cargo → v1.0.1 SHA
- denoland/setup-deno → v2.0.3 SHA