### PR TITLE
ci: migrate npm publish to OIDC trusted publishing (#29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,20 @@ on:
   push:
     tags:
       - '*'
+
+permissions:
+  contents: write   # GitHub release assets (svenstaro/upload-release-action)
+  id-token: write   # npm OIDC trusted publishing (no stored NPM_TOKEN)
+
 jobs:
   build_docker_images:
     strategy:
       max-parallel: 1
       matrix:
-        os: [ubuntu-latest]
+        os: [github-builder]
         arch: [amd64]
         include:
-          - os: ubuntu-latest
+          - os: github-builder
             arch: amd64
             platform: linux
     runs-on: ${{ matrix.os }}
@@ -22,30 +27,43 @@ jobs:
 
       - name: Get Version
         id: version
+        # Strip the leading 'v' so VER is a clean semver (e.g. 1.2.0) and the
+        # release tag below (v<version>) matches the actual git tag.
         run: |
-          echo "tag=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+            context: .
+            file: Dockerfile
             platforms: linux/${{ matrix.arch }}
-            build-args: VER= ${{ steps.version.outputs.tag }}
+            build-args: VER=${{ steps.version.outputs.tag }}
             load: true
             tags: wasm-ll:latest
-      - uses: shrink/actions-docker-extract@v3
-        id: extract
-        with:
-          image: wasm-ll:latest
-          path: pkg/
-          destination: dist
+            # Persistent layer cache — on the self-hosted runner subsequent
+            # builds reuse compiled layers (wasm-opt/wasm-pack/crate) instead
+            # of a cold build every tag.
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+      - name: Extract packages from image
+        # Deterministic copy of the built pkg-* dirs out of the wasm-ll image.
+        # --user keeps the files owned by the runner user so the persistent
+        # self-hosted workspace can be cleaned by the next run's Checkout.
+        run: |
+          mkdir -p dist
+          docker run --rm --user "$(id -u):$(id -g)" --entrypoint sh \
+            -v "$PWD/dist:/out" wasm-ll -c \
+            'cp -r /pkg/pkg-web /pkg/pkg-node /pkg/pkg-bundler /out/'
       - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
-        with:
-            type: 'zip'
-            filename: 'npm-packages-${{ steps.version.outputs.tag }}-${{ matrix.platform }}-${{ matrix.arch }}.zip'
-            path: dist
+        # zip-release action needs the system 'zip' binary which isn't on the
+        # self-hosted runner (and sudo isn't passwordless there) — use python3.
+        run: |
+          cd dist
+          python3 -m zipfile -c "../npm-packages-${{ steps.version.outputs.tag }}-${{ matrix.platform }}-${{ matrix.arch }}.zip" .
+          ls -lh "../npm-packages-${{ steps.version.outputs.tag }}-${{ matrix.platform }}-${{ matrix.arch }}.zip"
       - name: Upload archived  release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -55,8 +73,29 @@ jobs:
             tag: "v${{ steps.version.outputs.tag }}"
             overwrite: true
             file_glob: true
+      - name: Setup Node for publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Upgrade npm (OIDC trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@11
+
       - name: Publish to npm
+        # Publish from the runner (all GitHub OIDC env vars present), not from
+        # inside the container. npm CLI (>= 11.5.1) auto-exchanges the OIDC
+        # token for a short-lived npm token via Trusted Publishing. No stored
+        # NODE_AUTH_TOKEN: setup-node is used WITHOUT registry-url on purpose
+        # so it does not inject the repo's npm token.
+        # NOTE: no --provenance — this repo is private, and npm/sigstore
+        # provenance only supports public source repositories (E422 otherwise).
+        # Prerelease versions (e.g. 1.2.0-pre.x) require --tag; publish them
+        # under the 'next' dist-tag so they never become 'latest'.
+        env:
+          VERSION: ${{ steps.version.outputs.tag }}
         run: |
-          docker run --rm --tty -e NPM_TOKEN=${{ secrets.NPM_TOKEN }} wasm-ll bash -c "cd pkg-web; npm publish"
-          docker run --rm --tty -e NPM_TOKEN=${{ secrets.NPM_TOKEN }} wasm-ll bash -c "cd pkg-node; npm publish"
-          docker run --rm --tty -e NPM_TOKEN=${{ secrets.NPM_TOKEN }} wasm-ll bash -c "cd pkg-bundler; npm publish"
+          PUB_TAG=""
+          if [[ "$VERSION" == *-* ]]; then PUB_TAG="--tag next"; fi
+          ( cd dist/pkg-web && npm publish $PUB_TAG )
+          ( cd dist/pkg-node && npm publish $PUB_TAG )
+          ( cd dist/pkg-bundler && npm publish $PUB_TAG )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,14 @@ jobs:
         # token for a short-lived npm token via Trusted Publishing. No stored
         # NODE_AUTH_TOKEN: setup-node is used WITHOUT registry-url on purpose
         # so it does not inject the repo's npm token.
-        # NOTE: no --provenance — this repo is private, and npm/sigstore
-        # provenance only supports public source repositories (E422 otherwise).
+        # NOTE: provenance disabled — this repo is public, but npm/sigstore
+        # provenance does not support self-hosted runners (E422), and the
+        # publish runs on the github-builder fleet.
         # Prerelease versions (e.g. 1.2.0-pre.x) require --tag; publish them
         # under the 'next' dist-tag so they never become 'latest'.
         env:
           VERSION: ${{ steps.version.outputs.tag }}
+          NPM_CONFIG_PROVENANCE: 'false'
         run: |
           PUB_TAG=""
           if [[ "$VERSION" == *-* ]]; then PUB_TAG="--tag next"; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #     "cd pkg-node; npm publish"
 #
 
-FROM rust@sha256:80ccfb51023dbb8bfa7dc469c514a5a66343252d5e7c5aa0fab1e7d82f4ebbdc as builder
+FROM rust:1.88-bookworm as builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     set -e; \
     rustup target add wasm32-unknown-unknown; \
     cargo install wasm-opt; \
-    cargo install wasm-pack
+    cargo install wasm-pack --version 0.14.0 --locked
 
 WORKDIR /src
 

--- a/wrapper/wasm-ll/.npmrc
+++ b/wrapper/wasm-ll/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @silencelaboratories:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Description

Migrates npm publish to **OIDC trusted publishing** for [#29](https://github.com/silence-laboratories/DevOps_instructions/issues/29) — removes the stored `NPM_TOKEN`. Mirrors the already-validated sl-eddsa-ll fix (sl-eddsa-ll#32).

Changes:
- `release.yml`: `id-token: write`; publish from the runner (npm ≥11.5.1) — no stored token, no `--provenance` (private repo), prerelease versions → `next` dist-tag.
- **Build on the self-hosted `github-builder` fleet** + `type=gha` layer cache (replaces cold `ubuntu-latest` builds).
- **Fixed broken release pipeline**: `file: Dockerfile` + `context`, `VER` leading-space, `v`-prefix strip (was producing `vv` tags), deterministic pkg extraction with `--user`, python archive (self-hosted runner has no system `zip`).
- `wrapper/wasm-ll/.npmrc`: drop `_authToken=${NPM_TOKEN}`.

## Required (external)
1. On npmjs.com configure a **Trusted Publisher** for `@silencelaboratories/dkls-wasm-ll-web` / `-node` / `-bundler` → this repo + `release.yml` (allowed action `npm publish`).
2. After a successful canary, delete the `NPM_TOKEN` secret from the repo.
