### PR TITLE
chore(security): add Dependabot cooldown for cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add `cooldown: default-days: 7` to the cargo block in dependabot.yml.

Cargo has no native min-publish-age on stable (RFC #3923, nightly only), so Dependabot cooldown is the equivalent defense.

https://daniakash.com/posts/simplest-supply-chain-defense/
Ref: DevOps_instructions#45